### PR TITLE
Add mecab-juman build subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8.3
   - 1.9
+  - "1.10"
   - tip
 
 sudo: false

--- a/cmd/_dictool/juman/cmd.go
+++ b/cmd/_dictool/juman/cmd.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mecab
+package juman
 
 import (
 	"flag"
@@ -22,18 +22,18 @@ import (
 
 // subcommand property
 var (
-	CommandName  = "mecab"
-	Description  = `mecab dic build tool`
-	usageMessage = "%s -mecab mecabdic-path [-z]\n"
+	CommandName  = "juman"
+	Description  = `juman dic build tool`
+	usageMessage = "%s -mecab mecabdic-path [-neologd neologd-path] [-z]\n"
 	errorWriter  = os.Stderr
 )
 
 // options
 type option struct {
-	output   string
-	mecab    string
-	archive  bool
-	encoding string
+	output  string
+	mecab   string
+	neologd string
+	archive bool
 
 	flagSet *flag.FlagSet
 }
@@ -44,9 +44,9 @@ func newOption() (o *option) {
 	}
 	// option settings
 	o.flagSet.BoolVar(&o.archive, "z", true, "build an archived dic")
-	o.flagSet.StringVar(&o.output, "output", "mecab.dic", "set output path")
+	o.flagSet.StringVar(&o.output, "output", ".", "set output path")
 	o.flagSet.StringVar(&o.mecab, "mecab", "", "set mecab src path")
-	o.flagSet.StringVar(&o.encoding, "encoding", "utf8", "set mecab src encoding [utf8|eucjp|sjis|jis]")
+	o.flagSet.StringVar(&o.neologd, "neologd", "", "set neologd src path")
 	return
 }
 
@@ -66,37 +66,36 @@ func (o *option) parse(args []string) (err error) {
 
 // command main
 func command(opt *option) error {
-	d, err := buildMecabDic(opt.mecab, opt.encoding)
+	d, err := buildJumanDic(opt.mecab, opt.neologd)
 	if err != nil {
 		return err
 	}
-	if saveMecabDic(d, opt.output, opt.archive); err != nil {
-		return fmt.Errorf("build error: %v", err)
+	if saveJumanDic(d, opt.output, opt.archive); err != nil {
+		return fmt.Errorf("build error: %v\n", err)
 	}
 	return nil
 }
 
-// Run mecab command
 func Run(args []string) error {
 	if len(args) == 0 {
-		usage()
-		printDefaults()
+		Usage()
+		PrintDefaults()
 		return nil
 	}
 	opt := newOption()
 	if e := opt.parse(args); e != nil {
-		usage()
-		printDefaults()
+		Usage()
+		PrintDefaults()
 		return e
 	}
 	return command(opt)
 }
 
-func usage() {
+func Usage() {
 	fmt.Fprintf(os.Stderr, usageMessage, CommandName)
 }
 
-func printDefaults() {
+func PrintDefaults() {
 	o := newOption()
 	o.flagSet.PrintDefaults()
 }

--- a/cmd/_dictool/juman/cmd.go
+++ b/cmd/_dictool/juman/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2015 ikawaha
+// Copyright 2018 ikawaha
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/_dictool/juman/mkdic.go
+++ b/cmd/_dictool/juman/mkdic.go
@@ -1,4 +1,4 @@
-// Copyright 2015 ikawaha
+// Copyright 2018 ikawaha
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/_dictool/main.go
+++ b/cmd/_dictool/main.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/ikawaha/kagome/cmd/_dictool/ipa"
-	"github.com/ikawaha/kagome/cmd/_dictool/mecab"
+	"github.com/ikawaha/kagome/cmd/_dictool/juman"
 	"github.com/ikawaha/kagome/cmd/_dictool/uni"
 )
 
@@ -34,7 +34,7 @@ var subcommands = []struct {
 	// subcommands
 	{ipa.CommandName, ipa.Description, ipa.Run},
 	{uni.CommandName, uni.Description, uni.Run},
-	{mecab.CommandName, mecab.Description, mecab.Run},
+	{juman.CommandName, juman.Description, juman.Run},
 }
 
 func Usage() {

--- a/internal/dic/pos.go
+++ b/internal/dic/pos.go
@@ -28,7 +28,7 @@ type POSTable struct {
 }
 
 // POSID represents a ID of part of speech.
-type POSID int
+type POSID int16
 
 // POS represents a vector of part of speech.
 type POS []POSID


### PR DESCRIPTION
https://github.com/taku910/mecab/tree/master/mecab-jumandic
においてある mecab 用の juman 辞書をビルドできるようにしました．

動作確認はしたのですが，時間がなかったので細かくはチェックできてないです．

周囲点は以下です：

* ipadic のコードをコピペして，カラムの設定を変更
* encoding が utf8 だったので文字コード変換の部分を削除

大丈夫そうならまた pr いただけるとありがたいです．